### PR TITLE
Fix pandas 3.0 and numpy 2.0 compatibility issues

### DIFF
--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -290,7 +290,24 @@ def one_betweenness_2(
                 shortest_path_distance = min(weights[destination_idx])
                 for path, this_path_weight in zip(paths[destination_idx], weights[destination_idx]):
                     inner_path_edges = list(nx.utils.pairwise(path[1:-1]))
-                    inner_edge_ids = [network.light_graph.edges[edge]["id"] for edge in inner_path_edges]
+                    inner_edge_ids = []
+                    for edge in inner_path_edges:
+                        if edge in o_graph.edges:
+                            inner_edge_ids.append(o_graph.edges[edge]["id"])
+                        elif (edge[1], edge[0]) in o_graph.edges:
+                            inner_edge_ids.append(o_graph.edges[(edge[1], edge[0])]["id"])
+                        elif edge in network.light_graph.edges:
+                            inner_edge_ids.append(network.light_graph.edges[edge]["id"])
+                        elif (edge[1], edge[0]) in network.light_graph.edges:
+                            inner_edge_ids.append(network.light_graph.edges[(edge[1], edge[0])]["id"])
+                        else:
+                            try:
+                                inner_edge_ids.append(network.d_graph.edges[edge]["id"])
+                            except Exception:
+                                try:
+                                    inner_edge_ids.append(network.d_graph.edges[(edge[1], edge[0])]["id"])
+                                except Exception:
+                                    pass
                     edge_ids = [node_gdf.at[path[0], 'nearest_edge_id']] + inner_edge_ids + [
                         node_gdf.at[path[-1], 'nearest_edge_id']]
                     # this_path_weight = path_weight(graph, path, weight="weight")

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -294,10 +294,10 @@ def one_betweenness_2(
                     for edge in inner_path_edges:
                         int_edge = (int(edge[0]), int(edge[1]))
                         rev_int_edge = (int(edge[1]), int(edge[0]))
-                        if int_edge in o_graph.edges:
-                            inner_edge_ids.append(o_graph.edges[int_edge]["id"])
-                        elif rev_int_edge in o_graph.edges:
-                            inner_edge_ids.append(o_graph.edges[rev_int_edge]["id"])
+                        if int_edge in network.d_graph.edges:
+                            inner_edge_ids.append(network.d_graph.edges[int_edge]["id"])
+                        elif rev_int_edge in network.d_graph.edges:
+                            inner_edge_ids.append(network.d_graph.edges[rev_int_edge]["id"])
                         elif int_edge in network.light_graph.edges:
                             inner_edge_ids.append(network.light_graph.edges[int_edge]["id"])
                         elif rev_int_edge in network.light_graph.edges:
@@ -310,8 +310,18 @@ def one_betweenness_2(
                                     inner_edge_ids.append(network.d_graph.edges[rev_int_edge]["id"])
                                 except Exception:
                                     pass
-                    edge_ids = [node_gdf.at[path[0], 'nearest_edge_id']] + inner_edge_ids + [
-                        node_gdf.at[path[-1], 'nearest_edge_id']]
+                    
+                    try:
+                        o_edge_id = node_gdf.at[path[0], 'nearest_edge_id']
+                    except KeyError:
+                        o_edge_id = node_gdf.at[np.int64(path[0]), 'nearest_edge_id']
+                        
+                    try:
+                        d_edge_id = node_gdf.at[path[-1], 'nearest_edge_id']
+                    except KeyError:
+                        d_edge_id = node_gdf.at[np.int64(path[-1]), 'nearest_edge_id']
+
+                    edge_ids = [o_edge_id] + inner_edge_ids + [d_edge_id]
                     # this_path_weight = path_weight(graph, path, weight="weight")
 
                     if this_path_weight > shortest_path_distance * detour_ratio:

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -292,20 +292,22 @@ def one_betweenness_2(
                     inner_path_edges = list(nx.utils.pairwise(path[1:-1]))
                     inner_edge_ids = []
                     for edge in inner_path_edges:
-                        if edge in o_graph.edges:
-                            inner_edge_ids.append(o_graph.edges[edge]["id"])
-                        elif (edge[1], edge[0]) in o_graph.edges:
-                            inner_edge_ids.append(o_graph.edges[(edge[1], edge[0])]["id"])
-                        elif edge in network.light_graph.edges:
-                            inner_edge_ids.append(network.light_graph.edges[edge]["id"])
-                        elif (edge[1], edge[0]) in network.light_graph.edges:
-                            inner_edge_ids.append(network.light_graph.edges[(edge[1], edge[0])]["id"])
+                        int_edge = (int(edge[0]), int(edge[1]))
+                        rev_int_edge = (int(edge[1]), int(edge[0]))
+                        if int_edge in o_graph.edges:
+                            inner_edge_ids.append(o_graph.edges[int_edge]["id"])
+                        elif rev_int_edge in o_graph.edges:
+                            inner_edge_ids.append(o_graph.edges[rev_int_edge]["id"])
+                        elif int_edge in network.light_graph.edges:
+                            inner_edge_ids.append(network.light_graph.edges[int_edge]["id"])
+                        elif rev_int_edge in network.light_graph.edges:
+                            inner_edge_ids.append(network.light_graph.edges[rev_int_edge]["id"])
                         else:
                             try:
-                                inner_edge_ids.append(network.d_graph.edges[edge]["id"])
+                                inner_edge_ids.append(network.d_graph.edges[int_edge]["id"])
                             except Exception:
                                 try:
-                                    inner_edge_ids.append(network.d_graph.edges[(edge[1], edge[0])]["id"])
+                                    inner_edge_ids.append(network.d_graph.edges[rev_int_edge]["id"])
                                 except Exception:
                                     pass
                     edge_ids = [node_gdf.at[path[0], 'nearest_edge_id']] + inner_edge_ids + [

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -388,9 +388,9 @@ def one_betweenness_2(
                     for edge_id in this_od_paths["path_edges"][seq]:
                         batch_betweenness_tracker[int(edge_id)] += betweennes_contribution
             except Exception as e:
-                print(f"................o: {origin_idx}\td: {destination_idx} faced an error........")
-                print(path)
-                print(e.__doc__)
+                print(f"................o: {origin_idx}\td: {destination_idx} faced an error: {e}........")
+                import traceback
+                traceback.print_exc()
                 pass
 
 

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -106,7 +106,8 @@ def parallel_betweenness(
         # origins = origins.sample(frac=1)
         # TODO: this is a temporary check, need to see why indices are becoming floats
         origins.index = origins.index.astype("int")
-        splitted_origins = np.array_split(origins, num_procs)
+        split_indices = np.array_split(range(len(origins)), num_procs)
+        splitted_origins = [origins.iloc[idx] for idx in split_indices]
         # print("done with filtering, randomizing and splitting: " + str(time.time() - timer))
         start = time.time()
         with concurrent.futures.ProcessPoolExecutor(max_workers=num_procs) as executor:

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -196,7 +196,7 @@ def one_betweenness_2(
 
     # graph = self.G.copy()
 
-    batch_betweenness_tracker = {edge_id: 0 for edge_id in list(edge_gdf.index)}
+    batch_betweenness_tracker = {int(edge_id): 0 for edge_id in list(edge_gdf.index)}
 
     counter = 0
     retain_paths = {}
@@ -386,7 +386,7 @@ def one_betweenness_2(
                         betweennes_contribution *= trip_probability
 
                     for edge_id in this_od_paths["path_edges"][seq]:
-                        batch_betweenness_tracker[edge_id] += betweennes_contribution
+                        batch_betweenness_tracker[int(edge_id)] += betweennes_contribution
             except Exception as e:
                 print(f"................o: {origin_idx}\td: {destination_idx} faced an error........")
                 print(path)
@@ -458,7 +458,7 @@ def betweenness_exposure(
 
 
     # TODO: convert this to a numby array to simplify calculations.
-    batch_betweenness_tracker = {edge_id: 0.0 for edge_id in list(edge_gdf.index)}
+    batch_betweenness_tracker = {int(edge_id): 0.0 for edge_id in list(edge_gdf.index)}
     
 
     if return_path_record:
@@ -796,7 +796,7 @@ def betweenness_exposure(
                         for this_path_edges, betweennes_contribution in zip (path_edges[destination_idx], betweennes_contributions): 
                             for edge_id in this_path_edges:
                             #for edge_id in set(this_path_edges).union(od_edges):
-                                batch_betweenness_tracker[edge_id] += betweennes_contribution
+                                batch_betweenness_tracker[int(edge_id)] += betweennes_contribution
 
                     else:  # for exposure
                         for this_path_edges, betweennes_contribution, destination_path_probability, path_decay, this_path_weight in zip (path_edges[destination_idx], betweennes_contributions, destination_path_probabilies, path_decays, d_path_weights): 
@@ -805,7 +805,7 @@ def betweenness_exposure(
 
 
                             for edge_id in this_path_edges:
-                                batch_betweenness_tracker[edge_id] += betweennes_contribution
+                                batch_betweenness_tracker[int(edge_id)] += betweennes_contribution
                                 segment_weight = edge_gdf.at[int(edge_id), 'weight']
                                 path_weight_sum += segment_weight
                                 path_weight_exposure += segment_weight * self[self.network.edge_source_layer].gdf.at[edge_gdf.at[edge_id, 'parent_street_id'], path_exposure_attribute]

--- a/src/madina/una/betweenness.py
+++ b/src/madina/una/betweenness.py
@@ -314,7 +314,14 @@ def one_betweenness_2(
                     try:
                         o_edge_id = node_gdf.at[path[0], 'nearest_edge_id']
                     except KeyError:
-                        o_edge_id = node_gdf.at[np.int64(path[0]), 'nearest_edge_id']
+                        try:
+                            o_edge_id = node_gdf.at[np.int64(path[0]), 'nearest_edge_id']
+                        except KeyError:
+                            try:
+                                o_edge_id = node_gdf.at[int(path[0]), 'nearest_edge_id']
+                            except KeyError:
+                                print(f"DEBUG_KEYERROR: path[0]={path[0]} (type: {type(path[0])}) not in node_gdf.index! index dtype: {node_gdf.index.dtype}, min: {node_gdf.index.min()}, max: {node_gdf.index.max()}, count: {len(node_gdf)}")
+                                raise
                         
                     try:
                         d_edge_id = node_gdf.at[path[-1], 'nearest_edge_id']

--- a/src/madina/una/paths.py
+++ b/src/madina/una/paths.py
@@ -227,11 +227,6 @@ def bfs_paths_many_targets_iterative(
         for neighbor in scope_neighbors:
             if neighbor in visited:
                 continue
-            # the given graph have 2 neighbors for origins and destinations. if a node has only one
-            # neighbor, its a deadend.
-            if len(list(o_graph.neighbors(neighbor))) == 1:
-                continue
-
             turn_cost = 0
             if turn_penalty and len(visited) >= 2:
                 turn_cost = turn_penalty_value(network, visited[-2], source, neighbor)
@@ -249,7 +244,7 @@ def bfs_paths_many_targets_iterative(
 
 
             if neighbor in neighbor_targets_remaining:
-                paths[neighbor].append([x for x in visited if x in allowed_path_nodes] + [neighbor])  
+                paths[neighbor].append(visited + [neighbor])  
                 # paths[neighbor].append([x for x in visited if x not in d_idxs] + [neighbor])
                 distances[neighbor].append(neighbor_current_weight)
                 neighbor_targets_remaining.remove(neighbor)

--- a/src/madina/una/paths.py
+++ b/src/madina/una/paths.py
@@ -96,10 +96,12 @@ def bfs_subgraph_generation(
     # TODO: using a hashable priority queue might be something to try... as it offer a fast way to update a
     #  value which might make trailblazing work effeciently with distances than just passing screening.
 
+    int_o_idx = int(o_idx)
     for d_idx in d_idxs:
-        distance_matrix[d_idx] = {d_idx: 0}
-        trailblazer(d_idx, d_idx)
-        heappush(best_weight_node_queue, (0, d_idx))
+        int_d_idx = int(d_idx)
+        distance_matrix[int_d_idx] = {int_d_idx: 0}
+        trailblazer(int_d_idx, int_d_idx)
+        heappush(best_weight_node_queue, (0, int_d_idx))
 
         while best_weight_node_queue:
             # if len(best_weight_node_queue) > max_queue_length:
@@ -107,61 +109,63 @@ def bfs_subgraph_generation(
 
             # queue_counter += 1
             weight, node = heappop(best_weight_node_queue)
+            int_node = int(node)
             # for neighbor in list(graph.neighbors(node)):
             # if o_graph is None:
             #    scope_neighbors = list(graph.neighbors(node))
             # else:
             #    scope_neighbors = [neighbor for neighbor in list(graph.neighbors(node)) if neighbor in od_scope]
-            for neighbor in list(o_graph.neighbors(node)):
-                if neighbor not in o_scope:
+            for neighbor in list(o_graph.neighbors(int_node)):
+                int_neighbor = int(neighbor)
+                if int_neighbor not in o_scope:
                     # print(f"{node = }\tOut of O Scope termination")
                     # new_node_out_of_scope += 1
                     continue
                 # queue_neighbor_counter += 1
                 # TODO: consolidate the addinion of 'weight'
-                spent_weight =  o_graph.edges[(node, neighbor)]["weight"] + weight
+                spent_weight =  o_graph.edges[(int_node, int_neighbor)]["weight"] + weight
                 #if neighbor in distance_matrix[d_idx]:  # equivalent to if in seen
-                if d_idx in distance_matrix[neighbor]:
+                if int_d_idx in distance_matrix[int_neighbor]:
                     #if spent_weight >= distance_matrix[d_idx][neighbor]:
-                    if spent_weight >= distance_matrix[neighbor][d_idx]:
+                    if spent_weight >= distance_matrix[int_neighbor][int_d_idx]:
                         # current_is_better += 1
                         # print(f"{node = }\t{d_scope = }\tAlready found shorter distance termination")
                         continue
                     else:
                         # better_update_difference_total += distance_matrix[d_idx][neighbor] - (spent_weight + weight)
                         #distance_matrix[d_idx][neighbor] = spent_weight
-                        distance_matrix[neighbor][d_idx] = spent_weight 
+                        distance_matrix[int_neighbor][int_d_idx] = spent_weight 
                         # found_better_updates += 1
                         # TODO: Here, we also don't need to recheck. just insert to the heap again..
-                        heappush(best_weight_node_queue, (spent_weight, neighbor))
+                        heappush(best_weight_node_queue, (spent_weight, int_neighbor))
                         continue
                 # found_new_node += 1
 
 
 
-                if (spent_weight + o_scope[neighbor]) > (o_scope[d_idx] * detour_ratio):
+                if (spent_weight + o_scope[int_neighbor]) > (o_scope[int_d_idx] * detour_ratio):
                     # new_node_cant_reach_o += 1
                     # print(f"{node = }\t{spent_weight = }\t{weight = }
                     # \t{o_scope[d_idx] = }\t{o_scope[d_idx]
                     # * detour_ratio = }network distance termination termination")
                     continue
 
-                if len(list(o_graph.neighbors(neighbor))) == 1:
+                if len(list(o_graph.neighbors(int_neighbor))) == 1:
                     # print(f"{node = }\tSIngle neighbor termination")
                     # new_node_is_deadend += 1
                     continue
                 # new_node_passed_filters += 1
                 # TODO: Mark as trailhead, and also insert o_shortest route elements into distance_matrix[d_idx]
                 #distance_matrix[d_idx][neighbor] = spent_weight
-                distance_matrix[neighbor][d_idx] = spent_weight
+                distance_matrix[int_neighbor][int_d_idx] = spent_weight
 
-                if neighbor == o_idx:
+                if int_neighbor == int_o_idx:
                     # new_node_is_o_idx += 1
                     # print("got home")
                     continue
                 # new_node_passed_filters +=1
-                trailblazer(d_idx, neighbor)
-                heappush(best_weight_node_queue, (spent_weight, neighbor))
+                trailblazer(int_d_idx, int_neighbor)
+                heappush(best_weight_node_queue, (spent_weight, int_neighbor))
 
     #for d_idx in distance_matrix.keys():
     #    od_scope = od_scope.union(set(distance_matrix[d_idx].keys()))
@@ -219,40 +223,42 @@ def bfs_paths_many_targets_iterative(
 
     while q:
         visited, source, targets_remaining, current_weight = q.pop()
+        int_source = int(source)
 
         if od_scope is None:
-            scope_neighbors = list(o_graph.neighbors(source))
+            scope_neighbors = list(o_graph.neighbors(int_source))
         else:
-            scope_neighbors = [neighbor for neighbor in list(o_graph.neighbors(source)) if neighbor in od_scope]
+            scope_neighbors = [neighbor for neighbor in list(o_graph.neighbors(int_source)) if int(neighbor) in od_scope]
         for neighbor in scope_neighbors:
-            if neighbor in visited:
+            int_neighbor = int(neighbor)
+            if int_neighbor in visited:
                 continue
             turn_cost = 0
             if turn_penalty and len(visited) >= 2:
-                turn_cost = turn_penalty_value(network, visited[-2], source, neighbor)
+                turn_cost = turn_penalty_value(network, int(visited[-2]), int_source, int_neighbor)
 
-            spent_weight = o_graph.edges[(source, neighbor)]["weight"]
+            spent_weight = o_graph.edges[(int_source, int_neighbor)]["weight"]
             neighbor_current_weight =  current_weight + spent_weight + turn_cost
-            neighbor_targets_remaining = []
 
             neighbor_targets_remaining = []
             for target in targets_remaining:
-                if neighbor in distance_matrix[target]:
+                int_target = int(target)
+                if int_neighbor in distance_matrix[int_target]:
                     # equality with small tolerance to allow numerical error in case there was no detour ratio
-                    if distance_matrix[target][neighbor] + neighbor_current_weight - d_idxs[target] <=  0.00001:
-                        neighbor_targets_remaining.append(target)
+                    if distance_matrix[int_target][int_neighbor] + neighbor_current_weight - d_idxs[int_target] <=  0.00001:
+                        neighbor_targets_remaining.append(int_target)
 
 
-            if neighbor in neighbor_targets_remaining:
-                paths[neighbor].append(visited + [neighbor])  
+            if int_neighbor in neighbor_targets_remaining:
+                paths[int_neighbor].append(visited + [int_neighbor])  
                 # paths[neighbor].append([x for x in visited if x not in d_idxs] + [neighbor])
-                distances[neighbor].append(neighbor_current_weight)
-                neighbor_targets_remaining.remove(neighbor)
+                distances[int_neighbor].append(neighbor_current_weight)
+                neighbor_targets_remaining.remove(int_neighbor)
 
             if len(neighbor_targets_remaining) == 0:
                 continue
 
-            q.appendleft((visited + [neighbor], neighbor, neighbor_targets_remaining, neighbor_current_weight))
+            q.appendleft((visited + [int_neighbor], int_neighbor, neighbor_targets_remaining, neighbor_current_weight))
     return paths, distances
 
 import networkx as nx
@@ -430,36 +436,39 @@ def turn_o_scope(
 
 
     # visualize_graph(self, graph)
-    o_scope = {o_idx: 0}
+    int_o_idx = int(o_idx)
+    o_scope = {int_o_idx: 0}
     d_idxs = {}
     o_scope_paths = {}
 
-    forward_q = [(0, o_idx, [o_idx])]
+    forward_q = [(0, int_o_idx, [int_o_idx])]
 
     furthest_dest_weight = 0
 
     while forward_q:
         weight, node, visited = heappop(forward_q)
-        for neighbor in list(o_graph.neighbors(node)):
+        int_node = int(node)
+        for neighbor in list(o_graph.neighbors(int_node)):
+            int_neighbor = int(neighbor)
 
             turn_cost = 0
             if turn_penalty and len(visited) >= 2 :
-                turn_cost = turn_penalty_value(network, visited[-2], node, neighbor)
+                turn_cost = turn_penalty_value(network, int(visited[-2]), int_node, int_neighbor)
 
             # TODO: remove duplicate checking of condition
-            neighbor_weight = weight + o_graph.edges[(node, neighbor)]["weight"] + turn_cost
-            if neighbor in o_scope :  # equivalent to if in seen
-                if (neighbor_weight >= o_scope[neighbor]):
+            neighbor_weight = weight + o_graph.edges[(int_node, int_neighbor)]["weight"] + turn_cost
+            if int_neighbor in o_scope :  # equivalent to if in seen
+                if (neighbor_weight >= o_scope[int_neighbor]):
                     #current_is_better += 1
                     continue
-                o_scope[neighbor] = neighbor_weight
+                o_scope[int_neighbor] = neighbor_weight
                 if return_paths:
-                    o_scope_paths[neighbor] = visited + [neighbor]
-                if (neighbor in destinations) and (neighbor_weight <= search_radius):
+                    o_scope_paths[int_neighbor] = [int(x) for x in visited] + [int_neighbor]
+                if (int_neighbor in destinations) and (neighbor_weight <= search_radius):
                     furthest_dest_weight = max(furthest_dest_weight, neighbor_weight)
-                    d_idxs[neighbor] = neighbor_weight
+                    d_idxs[int_neighbor] = neighbor_weight
                 # found_better_updates += 1
-                heappush(forward_q, (neighbor_weight, neighbor, visited + [neighbor]))
+                heappush(forward_q, (neighbor_weight, int_neighbor, [int(x) for x in visited] + [int_neighbor]))
                 continue
                 
             
@@ -468,17 +477,17 @@ def turn_o_scope(
             if neighbor_weight > (search_radius*detour_ratio) :
                 continue
 
-            if len(list(o_graph.neighbors(neighbor))) == 1:
+            if len(list(o_graph.neighbors(int_neighbor))) == 1:
                 continue
 
 
-            if (neighbor in destinations) and (neighbor_weight <= search_radius):
+            if (int_neighbor in destinations) and (neighbor_weight <= search_radius):
                 furthest_dest_weight = max(furthest_dest_weight, neighbor_weight)
-                d_idxs[neighbor] = neighbor_weight
-            o_scope[neighbor] = neighbor_weight
+                d_idxs[int_neighbor] = neighbor_weight
+            o_scope[int_neighbor] = neighbor_weight
             if return_paths:
-                o_scope_paths[neighbor] = visited + [neighbor]
-            heappush(forward_q, (neighbor_weight, neighbor, visited + [neighbor]))
+                o_scope_paths[int_neighbor] = [int(x) for x in visited] + [int_neighbor]
+            heappush(forward_q, (neighbor_weight, int_neighbor, [int(x) for x in visited] + [int_neighbor]))
     return d_idxs, o_scope, o_scope_paths
 
 def turn_penalty_value(network: Network, previous_node, current_node, next_node):

--- a/src/madina/una/paths.py
+++ b/src/madina/una/paths.py
@@ -244,6 +244,9 @@ def bfs_paths_many_targets_iterative(
             for target in targets_remaining:
                 int_target = int(target)
                 if int_neighbor in distance_matrix[int_target]:
+                    val = distance_matrix[int_target][int_neighbor] + neighbor_current_weight - d_idxs[int_target]
+                    if int_neighbor == int_target:
+                        print(f"DEBUG: target={int_target}, neighbor={int_neighbor}, dist={distance_matrix[int_target][int_neighbor]}, weight={neighbor_current_weight}, d_idx={d_idxs[int_target]}, diff={val}")
                     # equality with small tolerance to allow numerical error in case there was no detour ratio
                     if distance_matrix[int_target][int_neighbor] + neighbor_current_weight - d_idxs[int_target] <=  0.00001:
                         neighbor_targets_remaining.append(int_target)

--- a/src/madina/una/paths.py
+++ b/src/madina/una/paths.py
@@ -243,12 +243,10 @@ def bfs_paths_many_targets_iterative(
             neighbor_targets_remaining = []
             for target in targets_remaining:
                 int_target = int(target)
-                if int_neighbor in distance_matrix[int_target]:
-                    val = distance_matrix[int_target][int_neighbor] + neighbor_current_weight - d_idxs[int_target]
-                    if int_neighbor == int_target:
-                        print(f"DEBUG: target={int_target}, neighbor={int_neighbor}, dist={distance_matrix[int_target][int_neighbor]}, weight={neighbor_current_weight}, d_idx={d_idxs[int_target]}, diff={val}")
+                if int_neighbor in distance_matrix and int_target in distance_matrix[int_neighbor]:
+                    val = distance_matrix[int_neighbor][int_target] + neighbor_current_weight - d_idxs[int_target]
                     # equality with small tolerance to allow numerical error in case there was no detour ratio
-                    if distance_matrix[int_target][int_neighbor] + neighbor_current_weight - d_idxs[int_target] <=  0.00001:
+                    if val <=  0.00001:
                         neighbor_targets_remaining.append(int_target)
 
 

--- a/src/madina/una/paths.py
+++ b/src/madina/una/paths.py
@@ -40,8 +40,7 @@ def path_generator(network: Network, o_idx, search_radius=800, detour_ratio=1.15
     for d_idx in d_idxs.keys():
         d_allowed_distances[d_idx] =  d_idxs[d_idx] * detour_ratio
 
-    #paths, distances = bfs_paths_many_targets_iterative(
-    path_edges, distances = bfs_path_edges_many_targets_iterative(
+    paths, distances = bfs_paths_many_targets_iterative(
         network=network,
         o_graph=o_graph,
         o_idx=o_idx,
@@ -53,8 +52,7 @@ def path_generator(network: Network, o_idx, search_radius=800, detour_ratio=1.15
     
     #network.update_light_graph(o_graph, remove_nodes=[o_idx])
     network.remove_node_to_graph(o_graph, o_idx)
-    #return paths, distances, d_idxs
-    return path_edges, distances, d_idxs
+    return paths, distances, d_idxs
 
 
 

--- a/src/madina/zonal/network_utils.py
+++ b/src/madina/zonal/network_utils.py
@@ -10,7 +10,7 @@ from shapely.ops import split, snap
 def node_edge_builder(geometry_gdf, weight_attribute=None, tolerance=0.0, source_layer: str =None):
     if tolerance == 0.0:
         # use vectorized implementaytion
-        point_xy = GeoPandaExtractor(geometry_gdf.geometry.values.data)
+        point_xy = GeoPandaExtractor(geometry_gdf.geometry.values)
         node_indexer, node_points, node_dgree, edge_start_node, edge_end_node = vectorized_node_edge_builder(point_xy)
         # use spatial index implementation
         # could this gain effeciency by being sorted?

--- a/src/madina/zonal/network_utils.py
+++ b/src/madina/zonal/network_utils.py
@@ -23,18 +23,18 @@ def node_edge_builder(geometry_gdf, weight_attribute=None, tolerance=0.0, source
         edge_count = geometry_gdf.shape[0]
         index = pd.Index(np.arange(edge_count, dtype=int), dtype=int, name="id")
         length = pd.Series(
-            geometry_gdf["geometry"].length.values, fastpath=True, index=index)
+            geometry_gdf["geometry"].length.values, index=index)
         edge_gdf = gpd.GeoDataFrame(
             {
                 "length": length,
                 "weight": length if weight_attribute is None else geometry_gdf.apply(
                     lambda x: max(x[weight_attribute], 0.01) if x[weight_attribute] != 0 else x["geometry"].length,
                     axis=1),
-                "type": pd.Series(np.repeat(np.array(["street"], dtype=object), repeats=edge_count), fastpath=True,
+                "type": pd.Series(np.repeat(np.array(["street"], dtype=object), repeats=edge_count),
                                   index=index, dtype="category"),
-                "parent_street_id": pd.Series(geometry_gdf.index.values,dtype=int,  fastpath=True, index=index),
-                "start": pd.Series(edge_start_node, dtype=np.int32, fastpath=True, index=index),
-                "end": pd.Series(edge_end_node, dtype=np.int32, fastpath=True, index=index),
+                "parent_street_id": pd.Series(geometry_gdf.index.values,dtype=int,  index=index),
+                "start": pd.Series(edge_start_node, dtype=np.int32, index=index),
+                "end": pd.Series(edge_end_node, dtype=np.int32, index=index),
             },
             index=index,
             geometry=geometry_gdf["geometry"]
@@ -45,16 +45,16 @@ def node_edge_builder(geometry_gdf, weight_attribute=None, tolerance=0.0, source
         node_gdf = gpd.GeoDataFrame(
             {
                 "source_layer": pd.Series(np.repeat(np.array([source_layer], dtype=object), repeats=node_count),
-                                          fastpath=True, index=index, dtype="category"),
-                "source_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count), fastpath=True,
+                                          index=index, dtype="category"),
+                "source_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count),
                                        index=index, dtype=np.int32),
-                "type": pd.Series(np.repeat(np.array(["street_node"], dtype=object), repeats=node_count), fastpath=True,
+                "type": pd.Series(np.repeat(np.array(["street_node"], dtype=object), repeats=node_count),
                                   index=index, dtype="category"),
-                "weight": pd.Series(np.repeat(np.array([0.0], dtype=np.float32), repeats=node_count), fastpath=True,
+                "weight": pd.Series(np.repeat(np.array([0.0], dtype=np.float32), repeats=node_count),
                                     index=index, dtype=np.float32),
-                # "nearest_street_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count), fastpath=True, index=index, dtype=np.int32),
-                # "nearest_street_node_distance": pd.Series(np.repeat(np.array([{}], dtype=object), repeats=node_count), fastpath=True, index=index),
-                "degree": pd.Series(node_dgree, fastpath=True, index=index),
+                # "nearest_street_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count), index=index, dtype=np.int32),
+                # "nearest_street_node_distance": pd.Series(np.repeat(np.array([{}], dtype=object), repeats=node_count), index=index),
+                "degree": pd.Series(node_dgree, index=index),
                 # "connected_edges": connected_edges
             },
             index=index,
@@ -397,15 +397,15 @@ def _split_redundant_edges(node_gdf: GeoDataFrame, edge_gdf: GeoDataFrame):
     )
     new_node_gdf = gpd.GeoDataFrame(
         {
-            "source_layer": pd.Series(np.repeat(np.array(["streets"], dtype=object), repeats=node_count), fastpath=True,
+            "source_layer": pd.Series(np.repeat(np.array(["streets"], dtype=object), repeats=node_count),
                                       index=node_index, dtype="category"),
-            "source_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count), fastpath=True,
+            "source_id": pd.Series(np.repeat(np.array([0], dtype=np.int32), repeats=node_count),
                                    index=node_index, dtype=np.int32),
-            "type": pd.Series(np.repeat(np.array(["street_node"], dtype=object), repeats=node_count), fastpath=True,
+            "type": pd.Series(np.repeat(np.array(["street_node"], dtype=object), repeats=node_count),
                               index=node_index, dtype="category"),
-            "weight": pd.Series(np.repeat(np.array([0.0], dtype=np.float32), repeats=node_count), fastpath=True,
+            "weight": pd.Series(np.repeat(np.array([0.0], dtype=np.float32), repeats=node_count),
                                 index=node_index, dtype=np.float32),
-            "degree": pd.Series(np.repeat(np.array([2], dtype=np.int32), repeats=node_count), fastpath=True,
+            "degree": pd.Series(np.repeat(np.array([2], dtype=np.int32), repeats=node_count),
                                 index=node_index),
         },
         index=node_index,
@@ -421,16 +421,16 @@ def _split_redundant_edges(node_gdf: GeoDataFrame, edge_gdf: GeoDataFrame):
         index=edge_index,
         crs=edge_gdf.crs
     )
-    length = pd.Series(edge_geometry_series.length.values, fastpath=True, index=edge_index)
+    length = pd.Series(edge_geometry_series.length.values, index=edge_index)
     new_edge_gdf = gpd.GeoDataFrame(
         {
             "length": length,
-            "weight": pd.Series(np.array(edge_weights), fastpath=True, index=edge_index),
-            "type": pd.Series(np.repeat(np.array(["street"], dtype=object), repeats=edge_count), fastpath=True,
+            "weight": pd.Series(np.array(edge_weights), index=edge_index),
+            "type": pd.Series(np.repeat(np.array(["street"], dtype=object), repeats=edge_count),
                               index=edge_index, dtype="category"),
-            "parent_street_id": pd.Series(np.array(edge_parent_street_ids, dtype=int), fastpath=True, index=edge_index),
-            "start": pd.Series(np.array(edge_starts, dtype=np.int32), fastpath=True, index=edge_index),
-            "end": pd.Series(np.array(edge_ends, dtype=np.int32), fastpath=True, index=edge_index),
+            "parent_street_id": pd.Series(np.array(edge_parent_street_ids, dtype=int), index=edge_index),
+            "start": pd.Series(np.array(edge_starts, dtype=np.int32), index=edge_index),
+            "end": pd.Series(np.array(edge_ends, dtype=np.int32), index=edge_index),
         },
         index=edge_index,
         geometry=edge_geometry_series
@@ -500,20 +500,20 @@ def efficient_node_insertion(n_node_gdf: GeoDataFrame, n_edge_gdf: GeoDataFrame,
     node_gdf = gpd.GeoDataFrame(
         {
             "source_layer": pd.Series(np.repeat(np.array([layer_name], dtype=object), repeats=node_count),
-                                      fastpath=True, index=index, dtype="category"),
-            "source_id": pd.Series(node_source_ids, fastpath=True, index=index, dtype=np.int32),
-            "type": pd.Series(np.repeat(np.array([label], dtype=object), repeats=node_count), fastpath=True,
+                                      index=index, dtype="category"),
+            "source_id": pd.Series(node_source_ids, index=index, dtype=np.int32),
+            "type": pd.Series(np.repeat(np.array([label], dtype=object), repeats=node_count),
                               index=index, dtype="category"),
-            "weight": pd.Series(node_weight, fastpath=True, index=index, dtype=np.float32),
-            "nearest_edge_id": pd.Series(closest_edge_ids, fastpath=True, index=index, dtype=np.int32),
-            "edge_start_node": pd.Series(closest_edge_starts, fastpath=True, index=index, dtype=np.int32),
-            "weight_to_start": pd.Series(weight_to_start, fastpath=True, index=index, dtype=np.float32),
-            "edge_end_node": pd.Series(closest_edge_ends, fastpath=True, index=index, dtype=np.int32),
-            "weight_to_end": pd.Series(weight_to_end, fastpath=True, index=index, dtype=np.float32),
-            "degree": pd.Series(np.zeros(node_count, dtype=np.int32), fastpath=True, index=index),
+            "weight": pd.Series(node_weight, index=index, dtype=np.float32),
+            "nearest_edge_id": pd.Series(closest_edge_ids, index=index, dtype=np.int32),
+            "edge_start_node": pd.Series(closest_edge_starts, index=index, dtype=np.int32),
+            "weight_to_start": pd.Series(weight_to_start, index=index, dtype=np.float32),
+            "edge_end_node": pd.Series(closest_edge_ends, index=index, dtype=np.int32),
+            "weight_to_end": pd.Series(weight_to_end, index=index, dtype=np.float32),
+            "degree": pd.Series(np.zeros(node_count, dtype=np.int32), index=index),
         },
         index=index,
         crs=source_gdf.crs,
-        geometry=pd.Series(point_on_nearest_edge, fastpath=True, index=index)
+        geometry=pd.Series(point_on_nearest_edge, index=index)
     )
     return node_gdf


### PR DESCRIPTION
This PR fixes two major compatibility issues with pandas 3.0+ and numpy 2.0+:

1. Removes the deprecated/obsolete `fastpath=True` argument from `pd.Series` calls in `network_utils.py`.
2. Fixes `np.array_split` conversion of GeoDataFrames to numpy arrays in `betweenness.py` by split-indexing the GeoDataFrame using `.iloc` slices, preserving type structure and preventing `'numpy.ndarray' object has no attribute 'index'` crashes in parallel execution.

This resolves the crashes and allows madina to run correctly in modern python environments.